### PR TITLE
feat: data/saas/のYAMLファイルをメインダッシュボードに自動表示する機能を実装

### DIFF
--- a/data/saas/biz-strategy.yaml
+++ b/data/saas/biz-strategy.yaml
@@ -4,7 +4,9 @@
   category: 6
   category_name: 事業構築
   title: 戦略
-  content: ""
+  content: "ターゲットセグメント、提供価値（JTBD）、チャネル・価格戦略、ロードマップを含む事業戦略の骨子を定義"
+  video: "/videos/biz_strategy.mp4"
+  features: ["ペルソナ定義", "JTBD分析", "収益モデル設計", "ロードマップ策定"]
   custom_html: |
     <style>
       .biz-doc { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 24px; }

--- a/data/saas/dynamic-media-gallery.yaml
+++ b/data/saas/dynamic-media-gallery.yaml
@@ -2,7 +2,9 @@
   category: 1
   category_name: ダッシュボード
   title: Dynamic Media Gallery
-  content: ""
+  content: "インタラクティブなメディアギャラリー - 画像、動画、3Dアセットをダイナミックに表示"
+  video: "/videos/media_gallery.mp4"
+  features: ["3Dビューワー", "動画プレビュー", "フィルタリング", "レスポンシブ表示"]
   custom_html: |
     <div style="background: #0f0f0f; border-radius: 12px; overflow: hidden; margin: 20px 0; min-height: 800px; position: relative;">
       <!-- ギャラリー埋め込み -->

--- a/data/saas/sns-marketing.yaml
+++ b/data/saas/sns-marketing.yaml
@@ -4,7 +4,9 @@
   category: 7
   category_name: SNS・マーケティング
   title: SNS・マーケティング
-  content: ""
+  content: "SNSマーケティング戦略とコンテンツプランニングのための要件定義書"
+  video: "/videos/sns_marketing.mp4"
+  features: ["コンテンツ戦略", "KPI設計", "投稿スケジューリング", "エンゲージメント分析"]
   markdown_file: static/data/pages/sns-marketing.md
   custom_html: |
     <div style="margin-bottom: 20px;">

--- a/data/sections.yaml
+++ b/data/sections.yaml
@@ -87,6 +87,10 @@
     
     <!-- ダッシュボードセクション -->
     <div class="dashboard-sections">
+      
+      <!-- 動的ダッシュボード：data/saas/の全YAMLファイルを自動読み込み -->
+      {{ partial "dynamic-saas-dashboard.html" . }}
+      
       <div class="dashboard-links">
         <a href="#" class="saas-app-card" onclick="window.location.hash=''; location.reload(); return false;">
           <video src="/videos/dashboard_card.mp4" alt="メインダッシュボード" style="width: 100%; height: 180px; object-fit: cover; border-radius: 8px; margin-bottom: 12px;" autoplay loop muted playsinline></video>

--- a/themes/kamui-docs/layouts/partials/dynamic-saas-dashboard.html
+++ b/themes/kamui-docs/layouts/partials/dynamic-saas-dashboard.html
@@ -1,0 +1,133 @@
+{{/* 
+  動的SaaS ダッシュボード生成パーシャルテンプレート
+  data/saas/ ディレクトリの全YAMLファイルを自動読み込みしてダッシュボードに表示
+*/}}
+
+{{ $saas_data := .Site.Data.saas }}
+{{ $sections := dict }}
+
+{{/* カテゴリ別にファイルを分類 */}}
+{{ range $file_name, $content := $saas_data }}
+  {{ range $item := $content }}
+    {{ if and $item.category $item.category_name }}
+      {{ $category := printf "%d" $item.category }}
+      {{ if not (index $sections $category) }}
+        {{ $sections = $sections | merge (dict $category slice) }}
+      {{ end }}
+      {{ $current_section := index $sections $category }}
+      {{ $sections = $sections | merge (dict $category ($current_section | append $item)) }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{/* カテゴリをソートして表示 */}}
+{{ $sorted_categories := sort (keys $sections) }}
+{{ range $category := $sorted_categories }}
+  {{ $items := index $sections $category }}
+  {{ if $items }}
+    {{ $first_item := index $items 0 }}
+    
+    <!-- カテゴリセクション -->
+    <div class="dashboard-section">
+      <h3 class="dashboard-section-title">{{ $first_item.category_name }}</h3>
+      
+      <div class="dashboard-links">
+        {{ range $item := $items }}
+          {{ $is_private := hasPrefix $item.id "private_" }}
+          {{ $card_link := printf "#%s" $item.id }}
+          
+          <a href="{{ $card_link }}" class="saas-app-card">
+            {{/* ビデオまたは画像の表示 */}}
+            {{ if $item.video }}
+              <video src="{{ $item.video }}" alt="{{ $item.title }}" style="width: 100%; height: 180px; object-fit: cover; border-radius: 8px; margin-bottom: 12px;" autoplay loop muted playsinline></video>
+            {{ else if $item.image }}
+              <img src="{{ $item.image }}" alt="{{ $item.title }}" style="width: 100%; height: 180px; object-fit: cover; border-radius: 8px; margin-bottom: 12px;" />
+            {{ else }}
+              {{/* デフォルトのプレースホルダー */}}
+              <div style="width: 100%; height: 180px; background: linear-gradient(135deg, #4a9eff 0%, #63b8ff 100%); border-radius: 8px; margin-bottom: 12px; display: flex; align-items: center; justify-content: center; color: white; font-size: 1.1rem; font-weight: bold;">
+                {{ $item.title }}
+              </div>
+            {{ end }}
+            
+            <div class="saas-app-title">
+              {{ if $is_private }}🔒 {{ end }}{{ $item.title }}
+              <span class="saas-app-arrow">→</span>
+            </div>
+            
+            {{ if $item.content }}
+              <div class="saas-app-description">{{ $item.content }}</div>
+            {{ else if $item.description }}
+              <div class="saas-app-description">{{ $item.description }}</div>
+            {{ end }}
+            
+            {{ if $item.features }}
+              <div class="saas-app-features">
+                {{ delimit $item.features " • " }}
+              </div>
+            {{ end }}
+            
+            {{/* サブアイテム（章の下階層）の表示 */}}
+            {{ if $item.tabs }}
+              <div class="saas-app-subitems">
+                <div class="subitem-label">章:</div>
+                {{ range $tab := $item.tabs }}
+                  <span class="subitem-tag">{{ $tab.icon }} {{ $tab.label }}</span>
+                {{ end }}
+              </div>
+            {{ else if $item.overview_cards }}
+              <div class="saas-app-subitems">
+                <div class="subitem-label">セクション:</div>
+                {{ range $card := $item.overview_cards }}
+                  <span class="subitem-tag">{{ $card.icon }} {{ $card.title }}</span>
+                {{ end }}
+              </div>
+            {{ else if $item.sections }}
+              <div class="saas-app-subitems">
+                <div class="subitem-label">セクション:</div>
+                {{ range $section := $item.sections }}
+                  <span class="subitem-tag">{{ $section.icon }} {{ $section.title }}</span>
+                {{ end }}
+              </div>
+            {{ end }}
+          </a>
+        {{ end }}
+      </div>
+    </div>
+  {{ end }}
+{{ end }}
+
+<style>
+  .dashboard-section {
+    margin-bottom: 40px;
+  }
+  
+  .saas-app-subitems {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
+  }
+  
+  .subitem-label {
+    font-size: 0.8rem;
+    color: var(--text-weak);
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+  
+  .subitem-tag {
+    display: inline-block;
+    font-size: 0.75rem;
+    background: rgba(74, 158, 255, 0.1);
+    color: #4a9eff;
+    padding: 2px 8px;
+    border-radius: 12px;
+    margin-right: 6px;
+    margin-bottom: 4px;
+    border: 1px solid rgba(74, 158, 255, 0.2);
+  }
+  
+  [data-theme="light"] .subitem-tag {
+    background: rgba(74, 158, 255, 0.08);
+    border: 1px solid rgba(74, 158, 255, 0.15);
+  }
+</style>


### PR DESCRIPTION
Closes #6

## 変更内容

data/saas/ディレクトリのYAMLファイルを自動的にメインダッシュボードに表示する機能を実装しました。

### 主な変更
- `themes/kamui-docs/layouts/partials/dynamic-saas-dashboard.html`: 動的ダッシュボード生成テンプレート作成
- `data/sections.yaml`: 動的テンプレート呼び出しを追加
- 主要YAMLファイルにメタデータ（video、features、description）を追加

### 解決した問題
- 欠落していたアイテム（8、9番等） → 全19個のYAMLファイルが自動表示
- 章の下階層が表示されない → tabs、overview_cards、sectionsをタグ形式で表示
- 手動でsections.yamlを編集する必要 → 完全自動化

### 機能
- data/saas/に新しいYAMLファイルを追加 → 自動的にメインダッシュボードに表示
- private_から始まるファイル → 🔒マーク付きで表示
- 章の下階層 → アイコン付きタグ形式でサブアイテムを表示
- 既存のスタイ・JS機能完全互換

Generated with [Claude Code](https://claude.ai/code)